### PR TITLE
Removed field map_flags

### DIFF
--- a/get-rekt-linux-hardened.c
+++ b/get-rekt-linux-hardened.c
@@ -55,8 +55,7 @@ int bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size,
 		.map_type = map_type,
 		.key_size = key_size,
 		.value_size = value_size,
-		.max_entries = max_entries,
-		.map_flags = map_flags,
+		.max_entries = max_entries
 	};
 
 	return syscall(__NR_bpf, BPF_MAP_CREATE, &attr, sizeof(attr));


### PR DESCRIPTION
This field should be removed beacuse there is no fileld like this in this union according to documentation. I wanted to compile this exploit on my Ubuntu 16.04 LTS but it didn't work. When I removed this fileld it works.